### PR TITLE
Improve code quality

### DIFF
--- a/src/pintest.cpp
+++ b/src/pintest.cpp
@@ -51,7 +51,7 @@ enum class ParseStatus {
 };
 
 // Parse the command line arguments
-auto parse_arguments(int argc, char* argv[]) {
+std::tuple<Arguments, ParseStatus> parse_arguments(int argc, char* argv[]) {
     Arguments args;
     namespace po = boost::program_options;
     po::options_description desc("Allowed options");


### PR DESCRIPTION
The function to parse command line arguments had `auto` as return type. That
has now been made explicit to improve API clearity.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Improve code quality by making the return type of the parse_arguments function explicit.

Enhancements:
- Make the return type of the parse_arguments function explicit to improve API clarity.

<!-- Generated by sourcery-ai[bot]: end summary -->